### PR TITLE
Compound Textile table cell specifiers

### DIFF
--- a/tablelib_test.py
+++ b/tablelib_test.py
@@ -279,21 +279,48 @@ class TextileSyntaxTest(BaseTableTest):
 |<. align left |
 | cell|
 |>. align right|
-|=. center |
+|=. center|
 |<>. justify |
 |^. valign top |
-|~. bottom |
+|~. bottom|
+|     >.  poor syntax
+|(className). class|
+|{key:value}. style|
 """.rstrip()
 
         expected = """\
-|_. attribute list |
-|<. align left     |
-|    cell          |
-|>.    align right |
-|=.     center     |
-|<>. justify       |
-|^. valign top     |
-|~. bottom         |
+|_.  attribute list |
+|<. align left      |
+| cell              |
+|>.     align right |
+|=.      center     |
+|<>. justify        |
+|^. valign top      |
+|~. bottom          |
+|>.     poor syntax |
+|(className). class |
+|{key:value}. style |
+""".rstrip()
+
+        t = tablelib.parse_table(self.syntax, unformatted)
+        formatted = t.render()
+        self.assert_table_equals(expected, formatted)
+
+    def testCompoundSyntax(self):
+        unformatted = """\
+|_>. header |_. centered header |
+|>^. right and top align | long text to show alignment |
+|=\\2. centered colspan|
+|<>(red). justified |~=. centered |
+|{text-shadow:0 1px 1px black;}(highlight)<~. syntax overload | normal text |
+""".rstrip()
+
+        expected = """\
+|_>.                                                   header |_.      centered header      |
+|>^.                                      right and top align | long text to show alignment |
+|=\\2.                                    centered colspan                                   |
+|<>(red). justified                                           |~=.         centered         |
+|{text-shadow:0 1px 1px black;}(highlight)<~. syntax overload | normal text                 |
 """.rstrip()
 
         t = tablelib.parse_table(self.syntax, unformatted)


### PR DESCRIPTION
Adds support for multiple specifiers within a single cell, for example right alignment within a header cell with `|_>.` or `|>_.` Updated tests include some very contrived cases of compound cell modifiers.

I was very glad to see that you are working on colspans and rowspans! This plugin will be very useful in the near future for updating our wiki with a few complex tables that would otherwise be unmanageable. I am glad to contribute a bit of free time to make that possible.
