### PR TITLE
Fix unwanted plugin trigger

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,119 +2,119 @@
     { "keys": ["ctrl+shift+a"], "command": "table_editor_align", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["tab"], "command": "table_editor_next_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["shift+tab"], "command": "table_editor_previous_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["enter"], "command": "table_editor_next_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+enter"], "command": "table_editor_split_column_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+j"], "command": "table_editor_join_lines", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+right"], "command": "table_editor_move_column_right", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+left"], "command": "table_editor_move_column_left", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+left"], "command": "table_editor_delete_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+right"], "command": "table_editor_insert_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+up"], "command": "table_editor_kill_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+down"], "command": "table_editor_insert_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+up"], "command": "table_editor_move_row_up", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+down"], "command": "table_editor_move_row_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","-"], "command": "table_editor_insert_single_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","="], "command": "table_editor_insert_double_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","enter"], "command": "table_editor_hline_and_move", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,119 +2,119 @@
     { "keys": ["ctrl+shift+a"], "command": "table_editor_align", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["tab"], "command": "table_editor_next_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["shift+tab"], "command": "table_editor_previous_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["enter"], "command": "table_editor_next_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+enter"], "command": "table_editor_split_column_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+j"], "command": "table_editor_join_lines", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+right"], "command": "table_editor_move_column_right", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+left"], "command": "table_editor_move_column_left", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+left"], "command": "table_editor_delete_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+right"], "command": "table_editor_insert_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+up"], "command": "table_editor_kill_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+down"], "command": "table_editor_insert_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+up"], "command": "table_editor_move_row_up", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+down"], "command": "table_editor_move_row_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","-"], "command": "table_editor_insert_single_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","="], "command": "table_editor_insert_double_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","enter"], "command": "table_editor_hline_and_move", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,119 +2,119 @@
     { "keys": ["ctrl+shift+a"], "command": "table_editor_align", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["tab"], "command": "table_editor_next_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["shift+tab"], "command": "table_editor_previous_field", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["enter"], "command": "table_editor_next_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+enter"], "command": "table_editor_split_column_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+j"], "command": "table_editor_join_lines", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+right"], "command": "table_editor_move_column_right", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+left"], "command": "table_editor_move_column_left", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+left"], "command": "table_editor_delete_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+right"], "command": "table_editor_insert_column", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+up"], "command": "table_editor_kill_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+shift+down"], "command": "table_editor_insert_row", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+up"], "command": "table_editor_move_row_up", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["alt+down"], "command": "table_editor_move_row_down", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "[\\|\\+]", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","-"], "command": "table_editor_insert_single_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","="], "command": "table_editor_insert_double_hline", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },
     { "keys": ["ctrl+k","enter"], "command": "table_editor_hline_and_move", "context":
         [
             { "key": "setting.enable_table_editor", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*[\\|\\+]", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(\\||\\+(---|===))", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "$", "match_all": true }
         ]
     },


### PR DESCRIPTION
If there was a `+` at the beginning of the line (ignoring whitespace prefix), this was enough for the plugin to trigger on several keybindings. This caused some unwanted operations in some cases. With this commit, it is now mandatory to have a `---` or `===` right after the initial `+` to trigger the plugin. This complies with Emacs and grid style table syntaxes.
