### PR TITLE
Fix wide character support: Halfwidth and fullwidth forms

### DIFF
--- a/widechar_support.py
+++ b/widechar_support.py
@@ -51,7 +51,9 @@ breakable_char_ranges = [
     # See http://en.wikipedia.org/wiki/Kanbun
     (0x3190, 0x319F),   # Kanbun
     # See http://en.wikipedia.org/wiki/Halfwidth_and_Fullwidth_Forms
-    (0xFF00, 0xFFEF),    # Halfwidth and Fullwidth Forms
+    (0xFF00, 0xFF5E),   # Fullwidth ASCII variants
+    (0xFF5F, 0xFF60),   # Fullwidth brackets
+    (0xFFE0, 0xFFE6),   # Fullwidth symbol variants
 ]
 
 


### PR DESCRIPTION
The following code is a Halfwidth (not wide) character.

* FF61 - FF64: Halfwidth CJK punctuation
* FF65 - FF9F: Halfwidth Katakana variants
* FFA0 - FFDC: Halfwidth Hangul variants
* FFE8 - FFEE: Halfwidth symbol variants

refs Halfwidth and Fullwidth Forms http://www.unicode.org/charts/PDF/UFF00.pdf

- - -

**old**

```
|    aaa     |         bbb          |         ccc          |
|------------|----------------------|----------------------|
| 12345      | 1234567890           | 1234567890           |
| ｱｲｳｴｵ | ｶﾞｷﾞｸﾞｹﾞｺﾞ | ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ |
```

![old](https://cloud.githubusercontent.com/assets/7358375/7366499/b6782e5a-edd3-11e4-86ae-89e7f7869481.png)

**new**

```
|  aaa  |    bbb     |    ccc     |
|-------|------------|------------|
| 12345 | 1234567890 | 1234567890 |
| ｱｲｳｴｵ | ｶﾞｷﾞｸﾞｹﾞｺﾞ | ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ |
```

![new](https://cloud.githubusercontent.com/assets/7358375/7366504/be2c7584-edd3-11e4-9a41-3fa40a549cbb.png)