### PR TITLE
Ensure README.md is rendered correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ It is true by default for textile syntax. You can disable it if you want
 {
     "table_editor_intelligent_formatting":false
 }
-``` 
+```
 
 Let you have a table
 


### PR DESCRIPTION
The space after ``` confuses some markdown parser. They think (somehow) that is not a code block terminator.

E.g. on https://packagecontrol.io/packages/Table%20Editor